### PR TITLE
Fix man page example

### DIFF
--- a/rc.1
+++ b/rc.1
@@ -1869,6 +1869,7 @@ This function allows the separator to be an arbitrary string.
 .Cr "    echo -n $1; shift"
 .Cr "    ~ $#* 0 && break"
 .Cr "    echo -n $lflat(2)"
+.Cr "  }"
 .Cr "}"
 .De
 .PP


### PR DESCRIPTION
Hi Toby,

A closing brace was missing, so copy-pasting from the man page resulted in a syntax error.