### PR TITLE
When running rc on the following script, rc crashes.

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -195,6 +195,7 @@ extern void delete_var(char *s, bool stack) {
 		}
 	} else { /* needs to be removed from the hash table */
 		efree(v);
+		vp[h].p = NULL;
 		efree(vp[h].name);
 		if (vp[(h+1)&(vsize-1)].name == NULL) {
 			--vused;


### PR DESCRIPTION
Script:
```
    fn f1 { v=x {  }}
    fn f2 { f1  1;  f1  2 }
    f2
    whatis
```
Valgrind stack:
```
    ==10068== Invalid read of size 8
    ==10068==    at 0x40EFB1: varlookup (var.c:84)
    ==10068==    by 0x407B04: whatare_all_vars (hash.c:311)
    ==10068==    by 0x401E60: b_whatis (builtins.c:323)
    ==10068==    by 0x402E32: exec (exec.c:92)
    ==10068==    by 0x40F997: walk (walk.c:39)
```

The reason is that `vp[h].p` is freed in `delete_var()`, but the pointer is kept unchanged.
Later the pointer is found to be non-null and dereferenced causing the crash.