### PR TITLE
Sigaction failing causes random value to be returned from sys_signal()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.o
 *~
 .deps/
 Makefile

--- a/signal.c
+++ b/signal.c
@@ -15,7 +15,9 @@ void (*sys_signal(int signum, void (*handler)(int)))(int) {
 	new.sa_handler = handler;
 	new.sa_flags = 0; /* clear SA_RESTART */
 	sigfillset(&new.sa_mask);
-	sigaction(signum, &new, &old);
+	if (0 != sigaction(signum, &new, &old)) {
+		old.sa_handler = SIG_DFL; /* set DFL to remove function, IGN creates empty func */
+	}
 	return old.sa_handler;
 }
 #else


### PR DESCRIPTION
In `sys_signal()` the call to `sigaction()` can fail. One failure mode is when `signum` is one of the unimplemented real time signals (holes in the signum range).
When that happens, the variable `struct sigaction old` will not be initialized and the returned value `old.sa_handler` contains a random value. Valgrind complains about that (the third error is at the same location as the second):

```
==20583== 2 errors in context 1 of 3:
==20583== Conditional jump or move depends on uninitialised value(s)
==20583==    at 0x10D988: inithandler (fn.c:35)
==20583==    by 0x113374: main (main.c:105)
==20583==  Uninitialised value was created by a stack allocation
==20583==    at 0x11665A: sys_signal (signal.c:12)
==20583==
==20583==
==20583== 2 errors in context 2 of 3:
==20583== Conditional jump or move depends on uninitialised value(s)
==20583==    at 0x11672E: initsignal (signal.c:102)
==20583==    by 0x11322D: main (main.c:83)
==20583==  Uninitialised value was created by a stack allocation
==20583==    at 0x11665A: sys_signal (signal.c:12)
```

This fix sets `old.sa_handler` to `SIG_DFL` when `sigaction()` fails. SIG_DFL was chosen over SIG_IGN because SIG_IGN creates an rc function with empty body.
 A different fix could detect non-existing signal numbers and avoid calls to `sys_signal()` with those values.
