### PR TITLE
Fix breaking out of loops through local variable blocks

### DIFF
--- a/except.c
+++ b/except.c
@@ -66,7 +66,7 @@ extern void rc_raise(ecodes e) {
 		exit(1); /* child processes exit on an error/signal */
 	for (; estack != NULL; estack = estack->prev)
 		if (estack->e != e) {
-			if (e == eBreak && estack->e != eArena)
+			if (e == eBreak && estack->e != eArena && estack->e != eVarstack)
 				rc_error("break outside of loop");
 			else if (e == eReturn && estack->e == eError) /* can return from loops inside functions */
 				rc_error("return outside of function");


### PR DESCRIPTION
This code:

```
while () {
    var = 1 {
        break
    }
}
```

caused an 'break outside of loop' error. Handling `eVarstack` like `eArena` in `rc_raise()` fixes this.
