### PR TITLE
Fix: "rc -e" exits if condition in while statement returns false the second time

### DIFF
--- a/rc.1
+++ b/rc.1
@@ -226,8 +226,12 @@ will exit if any command fails (exits with non-zero status). However
 .I "rc -e"
 does not exit if a conditional fails. A conditional is the test of an
 .Cr "if ()"
+command, the test of a
+.Cr "while ()"
 command, or the left hand side of the
 .Cr ||
+or the 
+.Cr &&
 operator.
 .TP
 .Cr \-i

--- a/trip.rc
+++ b/trip.rc
@@ -603,3 +603,9 @@ submatch 'echo foo = bar' 'foo = bar' 'unquoted equals 2'
 submatch 'echo foo=bar' 'foo=bar' 'unquoted equals 2'
 submatch 'echo foo=' 'foo=' 'unquoted equals 3'
 submatch 'echo =bar; whatis -v echo' 'echo=bar' 'unquoted equals 4'
+###############################################################
+X=`{ $rc -ec 'b=true; while($b){b=false}; echo YYY' }
+if (! ~ $X YYY) {
+    fail '"rc -e" exits when condition in the while statement fails in the second iteration'
+}
+###############################################################

--- a/walk.c
+++ b/walk.c
@@ -110,6 +110,7 @@ top:	sigchk();
 			cond = oldcond;
 			break;
 		}
+		cond = oldcond;
 		if (sigsetjmp(j.j, 1))
 			break;
 		jbreak.jb = &j;
@@ -117,12 +118,12 @@ top:	sigchk();
 		do {
 			Edata block;
 			block.b = newblock();
-			cond = oldcond;
 			except(eArena, block, &e2);
 			walk(n->u[1].p, TRUE);
-			testtrue = walk(n->u[0].p, TRUE);
-			unexcept(); /* eArena */
 			cond = TRUE;
+			testtrue = walk(n->u[0].p, TRUE);
+			cond = oldcond;
+			unexcept(); /* eArena */
 		} while (testtrue);
 		cond = oldcond;
 		unexcept(); /* eBreak */


### PR DESCRIPTION
Fixes issue [https://github.com/rakitzis/rc/issues/34](https://github.com/rakitzis/rc/issues/34) where  "rc -e" exits when condition in a while loop returns false the second time.
From the issue:
```
; ./rc -e
; b=true; while($b) { b=false } ; echo YYY
exiting
```