### PR TITLE
Continue builtin

### DIFF
--- a/builtins.c
+++ b/builtins.c
@@ -20,7 +20,7 @@
 #include "rlimit.h"
 #include "sigmsgs.h"
 
-static void b_break(char **), b_cd(char **), b_eval(char **), b_exit(char **),
+static void b_break(char **), b_cd(char **), b_continue(char **), b_eval(char **), b_exit(char **),
 	b_newpgrp(char **), b_return(char **), b_shift(char **), b_umask(char **),
 	b_wait(char **), b_whatis(char **);
 
@@ -39,6 +39,7 @@ static struct {
 	{ b_break,	"break" },
 	{ b_builtin,	"builtin" },
 	{ b_cd,		"cd" },
+	{ b_continue,   "continue" },
 #if RC_ECHO
 	{ b_echo,	"echo" },
 #endif
@@ -83,8 +84,8 @@ extern void funcall(char **av) {
 	except(eVarstack, star, &e2);
 	walk(treecpy(fnlookup(*av), nalloc), TRUE);
 	varrm("*", TRUE);
-	unexcept(); /* eVarstack */
-	unexcept(); /* eReturn */
+	unexcept(eVarstack); 
+	unexcept(eReturn); 
 }
 
 static void arg_count(char *name) {
@@ -214,6 +215,16 @@ static void b_break(char **av) {
 		return;
 	}
 	rc_raise(eBreak);
+}
+
+/* raise a "continue" exception to finish early an iteration of 'for' and 'while' loops */
+
+static void b_continue(char **av) {
+	if (av[1] != NULL) {
+		arg_count("continue");
+		return;
+	}
+	rc_raise(eContinue);
 }
 
 /* shift $* n places (default 1) */
@@ -401,7 +412,7 @@ extern void b_dot(char **av) {
 	except(eVarstack, star, &e);
 	doit(TRUE);
 	varrm("*", TRUE);
-	unexcept(); /* eVarstack */
+	unexcept(eVarstack);
 	interactive = old_i;
 }
 

--- a/builtins.c
+++ b/builtins.c
@@ -39,7 +39,7 @@ static struct {
 	{ b_break,	"break" },
 	{ b_builtin,	"builtin" },
 	{ b_cd,		"cd" },
-	{ b_continue,   "continue" },
+	{ b_continue,	"continue" },
 #if RC_ECHO
 	{ b_echo,	"echo" },
 #endif

--- a/builtins.c
+++ b/builtins.c
@@ -84,8 +84,8 @@ extern void funcall(char **av) {
 	except(eVarstack, star, &e2);
 	walk(treecpy(fnlookup(*av), nalloc), TRUE);
 	varrm("*", TRUE);
-	unexcept(eVarstack); 
-	unexcept(eReturn); 
+	unexcept(eVarstack);
+	unexcept(eReturn);
 }
 
 static void arg_count(char *name) {

--- a/except.c
+++ b/except.c
@@ -22,13 +22,14 @@ extern void except(ecodes e, Edata data, Estack *ex) {
 	estack = ex;
 	estack->e = e;
 	estack->data = data;
-	if (e == eError || e == eBreak || e == eReturn)
+	if (e == eError || e == eBreak || e == eReturn || e == eContinue)
 		estack->interactive = interactive;
 }
 
 /* remove an exception, restore last interactive value */
 
-extern void unexcept() {
+extern void unexcept(ecodes e) {
+	assert(e == estack->e);
 	switch (estack->e) {
 	default:
 		break;
@@ -66,8 +67,10 @@ extern void rc_raise(ecodes e) {
 		exit(1); /* child processes exit on an error/signal */
 	for (; estack != NULL; estack = estack->prev)
 		if (estack->e != e) {
-			if (e == eBreak && estack->e != eArena && estack->e != eVarstack)
+			if (e == eBreak && (estack->e != eArena && estack->e != eVarstack && estack->e != eContinue))
 				rc_error("break outside of loop");
+			else if (e == eContinue && (estack->e != eVarstack))
+				rc_error("continue outside of loop");
 			else if (e == eReturn && estack->e == eError) /* can return from loops inside functions */
 				rc_error("return outside of function");
 			switch (estack->e) {

--- a/input.c
+++ b/input.c
@@ -314,10 +314,10 @@ extern Node *doit(bool clobberexecit) {
 			else if (dashex && dashen)
 				fprint(2, "%T\n", parsetree);
 		}
-		unexcept(); /* eArena */
+		unexcept(eArena);
 	}
 	popinput();
-	unexcept(); /* eError */
+	unexcept(eError);
 	return parsetree;
 }
 

--- a/rc.1
+++ b/rc.1
@@ -1662,6 +1662,17 @@ With no argument,
 changes the current directory to
 .Cr "$home" .
 .TP
+.B continue
+Continues the innermost
+.Cr for
+or
+.Cr while
+loop,
+as in C.
+It is an error to invoke
+.B continue
+outside of a loop.
+.TP
 \fBecho \fR[\fB\-n\fR] [\fB\-\|\-\fR] [\fIarg ...\fR]
 Prints its arguments to standard output, terminated by a newline.
 Arguments are separated by spaces.

--- a/rc.h
+++ b/rc.h
@@ -185,7 +185,7 @@ extern bool outstanding_cmdarg(void);
 extern void pop_cmdarg(bool);
 extern void rc_raise(ecodes);
 extern void except(ecodes, Edata, Estack *);
-extern void unexcept(ecodes e);
+extern void unexcept(ecodes);
 extern void rc_error(char *);
 extern void sigint(int);
 

--- a/rc.h
+++ b/rc.h
@@ -41,7 +41,7 @@ typedef enum nodetype {
 } nodetype;
 
 typedef enum ecodes {
-	eError, eBreak, eReturn, eVarstack, eArena, eFifo, eFd
+	eError, eBreak, eReturn, eVarstack, eArena, eFifo, eFd, eContinue
 } ecodes;
 
 typedef enum bool {
@@ -185,7 +185,7 @@ extern bool outstanding_cmdarg(void);
 extern void pop_cmdarg(bool);
 extern void rc_raise(ecodes);
 extern void except(ecodes, Edata, Estack *);
-extern void unexcept(void);
+extern void unexcept(ecodes e);
 extern void rc_error(char *);
 extern void sigint(int);
 

--- a/trip.rc
+++ b/trip.rc
@@ -598,6 +598,78 @@ x=$tmpdir/qux*/foo
 
 rm -rf $tmpdir
 
+#############################################################################
+## Check builtin continue in while loop.
+#############################################################################
+q=''''
+C=$q^while-continue$q
+L=()
+
+ten = a^(1 2 3 4 5 6 7 8 9 10)
+* = $ten
+for (n) {
+  if (~ $n a2 a3) {
+    continue
+  }
+  L=($L $n)
+}
+if (!~ $#L 8) {
+  fail Wrong length of list from $C: $#L
+}
+if (!~ $L(1) a1) {
+  fail First element of $C list is not a1: $L(1)
+}
+if (!~ $L(2) a4) {
+  fail Second element of $C list is not a4: $L(2)
+}
+C=() L=()
+
+#############################################################################
+## Check builtin continue in for loop.
+#############################################################################
+C=$q^for-continue$q
+L=()
+
+for (x in a b c d e f g) {
+  if (~ $x c f) {
+    continue
+  }
+  L=($L $x)
+}
+if (!~ $#L 5) {
+  fail Wrong length of list from $C
+}
+if (!~ $L(1) a) {
+  fail First element of $C list is not a: $L(1)
+}
+if (!~ $L(3) d) {
+  fail Third element of $C list is not d: $L(3)
+}
+if (!~ $L(5) g) {
+  fail Fifth element of $C list is not g: $L(5)
+}
+C=() L=()
+
+submatch continue 'rc: continue outside of loop' 'continue outside of loop'
+
+#############################################################################
+## check builtin continue in for loop (2)
+#############################################################################
+L=()
+for (x in a b c d e f g) {
+  if (~ $x b d) {
+    continue
+  }
+  L=($L $x)
+  if (~ $x f) {
+    break;
+  }
+}
+
+if (!~ $^L 'a c e f') {
+  fail List should be '(a c e f)', but is $L
+}
+
 # test support for unquoted =
 submatch 'echo foo = bar' 'foo = bar' 'unquoted equals 2'
 submatch 'echo foo=bar' 'foo=bar' 'unquoted equals 2'

--- a/trip.rc
+++ b/trip.rc
@@ -605,14 +605,18 @@ q=''''
 C=$q^while-continue$q
 L=()
 
+save_star = *
 ten = a^(1 2 3 4 5 6 7 8 9 10)
 * = $ten
-for (n) {
+while (! ~ $#* 0) {
+  n = $1; shift
   if (~ $n a2 a3) {
     continue
   }
   L=($L $n)
 }
+* = $save_star; save_star = ()
+
 if (!~ $#L 8) {
   fail Wrong length of list from $C: $#L
 }

--- a/walk.c
+++ b/walk.c
@@ -375,7 +375,7 @@ static void dopipe(Node *n) {
 /* From http://en.cppreference.com/w/c/program/setjmp
  * According to the C standard setjmp() must appear only in the following 4 constructs:
  *   1. switch (setjmp(args)) {statements}
- *   2. if (setjmp(args) == Const) {statements} with any of 
+ *   2. if (setjmp(args) == Const) {statements} with any of
  *             operators: ==, !=, <, >, <=, >=
  *   3. while (! setjmp(args)) {statements}
  *   4. setjmp(args);


### PR DESCRIPTION
1. Implements `continue` builtin.
2. Adds exception `eContinue` to be raised in builtin `continue`
3. Set exception `eContinue` when walking `nWhile` or `nForin`
4. Added tests for `continue` in `while` and in `for` to _trip.rc_. 