### PR TITLE
Silence parser conflicts caused by IF NOT

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -16,6 +16,7 @@ Node *parsetree;	/* not using yylval because bison declares it as an auto */
 %token ANDAND BACKBACK BANG CASE COUNT DUP ELSE END FLAT FN FOR IF IN NOT
 %token OROR PIPE REDIR SREDIR SUB SUBSHELL SWITCH TWIDDLE WHILE WORD HUH
 
+%left NOT
 %left '^' '='
 %right ELSE TWIDDLE
 %left WHILE ')'


### PR DESCRIPTION
The changes in the grammar by commit 5966ab2 cause 3 shift/reduce conflict warnings during build.
We need an appropriate precedence rule to silence these warnings without changing how the conflicts get solved, i.e. shifting instead of reducing an incomplete `if not cmd`.