### PR TITLE
old_if_state changed from static variable to a stack variable

### DIFF
--- a/trip.rc
+++ b/trip.rc
@@ -716,3 +716,28 @@ submatch 'flag xx' 'usage: flag f [ + | - ]' 'flag wrong first arg'
 submatch 'flag x x' 'usage: flag f [ + | - ]' 'flag wrong second arg'
 submatch 'flag c && echo yes' yes 'flag c'
 submatch 'flag x +; flag x -' 'flag x -' 'setting x flag'
+
+# if-not stack if_state check
+ss=(
+  'L=()'
+  'if (true) {'
+  '    if (false) {'
+  '        L=($L  a1)'
+  '    }'
+  '    if not L=($L  a2)'
+  '}'
+  'if not L=($L  a3)'
+  'echo $L'
+)
+
+s=''
+for (a in $ss) {
+  s=$s$a$nl
+}
+m=`{$rc -c $s}
+whatis -v s m
+if (! ~ $^m a2) {
+    fail '"if not" not correct'
+}
+
+

--- a/trip.rc
+++ b/trip.rc
@@ -718,22 +718,18 @@ submatch 'flag c && echo yes' yes 'flag c'
 submatch 'flag x +; flag x -' 'flag x -' 'setting x flag'
 
 # if-not stack if_state check
-ss=(
-  'L=()'
-  'if (true) {'
-  '    if (false) {'
-  '        L=($L  a1)'
-  '    }'
-  '    if not L=($L  a2)'
-  '}'
-  'if not L=($L  a3)'
-  'echo $L'
-)
-
-s=''
-for (a in $ss) {
-  s=$s$a$nl
+s='
+L=()
+if (true) {
+    if (false) {
+        L=($L  a1)
+    }
+    if not L=($L  a2)
 }
+if not L=($L  a3)
+echo $L
+'
+
 m=`{$rc -c $s}
 whatis -v s m
 if (! ~ $^m a2) {

--- a/walk.c
+++ b/walk.c
@@ -19,7 +19,6 @@ static bool dofork(bool);
 static void dopipe(Node *);
 static void loop_body(Node* n);
 static int if_state = 2; /* last if, for "if not" interactive top-level */
-static int old_if_state = 2;
 
 /* Tail-recursive version of walk() */
 
@@ -101,9 +100,11 @@ top:	sigchk();
 		cond = TRUE;
 		if_state = walk(n->u[0].p, TRUE);
 		cond = oldcond;
-		old_if_state = if_state;
-		walk(if_state ? true_cmd : false_cmd, parent);
-		if_state = old_if_state;
+		{
+			const int old_if_state = if_state;
+			walk(if_state ? true_cmd : false_cmd, parent);
+			if_state = old_if_state;
+		}
 		break;
 	}
 	case nIfnot: {


### PR DESCRIPTION
The test is added to `trip.rc`. The test fails in the pre-pull master version.
This does not necessarily resolve all issues with `if not`.