### PR TITLE
Allow builtin wait more than one argument

### DIFF
--- a/Futures
+++ b/Futures
@@ -8,5 +8,3 @@ Faster; smaller; cheaper.
 Dynamically load readline and friends.
 
 Make --disable-def-interp the default.
-
-Allow builtin wait more than one argument.

--- a/builtins.c
+++ b/builtins.c
@@ -329,28 +329,13 @@ static void b_shift(char **av) {
 extern void b_builtin(char **ignore) {
 }
 
-/* wait for a given process, or all outstanding processes */
+/* wait for one or more processes, or all outstanding processes */
 
 static void b_wait(char **av) {
-	int status;
-	pid_t pid;
-	if (av[1] == NULL) {
+	if (*++av == NULL)
 		waitforall();
-		return;
-	}
-	if (av[2] != NULL) {
-		arg_count("wait");
-		return;
-	}
-	if ((pid = a2u(av[1])) < 0) {
-		badnum(av[1]);
-		return;
-	}
-	if (rc_wait4(pid, &status, FALSE) > 0)
-		setstatus(pid, status);
 	else
-		set(FALSE);
-	sigchk();
+		setwaitstatus(av, "wait");
 }
 
 /*

--- a/rc.1
+++ b/rc.1
@@ -1867,17 +1867,19 @@ to the octal
 .IR mask .
 If no argument is present, the current mask value is printed.
 .TP
-\fBwait \fR[\fIpid\fR]
-Waits for process with the specified
-.IR pid ,
+\fBwait \fR[\fIpid ...\fR]
+Waits for one or more processes with the specified
+.IR pid s,
 which must have been started by
 .IR rc ,
-to exit.
+to exit. The status of each specified process is appended to
+.Cr " $status" .
 If no
 .I pid
 is specified,
 .I rc
-waits for all its child processes to exit.
+waits for all its child processes to exit, and returns the
+status of the last one.
 .TP
 \fBwhatis \fR[\fB\-b\fR] \fR[\fB\-f\fR] \fR[\fB\-p\fR] \fR[\fB\-s\fR] \fR[\fB\-v\fR] [\fB\-\|\-\fR] [\fIname ...\fR]
 Prints a definition of the named objects.

--- a/rc.h
+++ b/rc.h
@@ -356,6 +356,7 @@ extern void set(bool);
 extern void setstatus(pid_t, int);
 extern List *sgetstatus(void);
 extern void setpipestatus(int [], int);
+extern void setwaitstatus(char **, char *);
 extern void ssetstatus(char **);
 extern char *strstatus(int s);
 

--- a/status.c
+++ b/status.c
@@ -5,6 +5,8 @@
 #include "statval.h"
 #include "wait.h"
 
+#include <errno.h>
+
 /* status == the wait() value of the last command in the pipeline, or the last command */
 
 static void statprint(pid_t, int);
@@ -54,6 +56,45 @@ extern void setpipestatus(int stats[], int num) {
 		statuses[i] = stats[i];
 		statprint(-1, stats[i]);
 	}
+}
+
+/* wait on multiple processes and store their exit status */
+
+extern void setwaitstatus(char **av, char *cmd) {
+	int i, j, count;
+	pid_t pid;
+
+	for (count = 0; av[count] != NULL; count++)
+		;
+	
+	/* ensure we have enough space to store all the results */
+	if (count >= sizeof(statuses)) {
+		fprint(2, RC "too many arguments to %s\n", cmd);
+		set(FALSE);
+		return;
+	}
+
+	/* we need to fill statuses backwards */
+	for (i = 0; i < count; i++) {
+		j = count - i - 1;
+		if ((pid = a2u(av[i])) < 0) {
+			fprint(2, RC "`%s' is a bad number\n", av[i]);
+			statuses[j] = 0x100;
+			continue;
+		}
+		if (rc_wait4(pid, statuses+j, FALSE) > 0) {
+			statprint(pid, statuses[j]);
+		} else {
+			statuses[j] = 0x100;
+			if (errno == EINTR) {
+				set(FALSE);
+				return;
+			}
+		}
+		sigchk();
+	}
+
+	pipelength = count;
 }
 
 /* set a simple status, as opposed to a pipeline */

--- a/trip.rc
+++ b/trip.rc
@@ -240,8 +240,6 @@ for (i in 1 2 3 4 5)
 if (!~ $i 2)
 	fail break out of loop
 
-submatch 'wait foo' 'rc: `foo'' is a bad number' 'bogus argument to wait'
-
 if (~ `{echo -n} ?)
 	fail echo -n
 if (!~ `` '' {echo --} $nl)
@@ -319,13 +317,16 @@ submatch 'cdpath='''' cd frobnatz' 'couldn''t cd to frobnatz' 'cd to frobnatz su
 # wait
 #
 
-submatch 'wait 1 2 3' 'rc: too many arguments to wait' 'wait arg count'
+submatch 'wait foo' 'rc: `foo'' is a bad number' 'bogus argument to wait'
 $rc -c 'wait 1' >[2]/dev/null && fail wait 1
 
-sleep 3&
-expect $apid
-echo $apids
-wait
+sleep 2&
+~ $#apid 1 || fail 'empty $apid'
+~ $apid $"apids || fail '$apid should match $apids'
+wait $apid || fail 'wait 1 arg'
+
+submatch 'true&false&true&true&false& wait $apids; echo $status' '0 1 0 0 1' 'multi wait'
+submatch 'wait a b; echo $status' '1 1' 'multi wait wrong numbers'
 
 if (~ `` '' {wait} ?)
 	fail waiting for nothing


### PR DESCRIPTION
When waiting on multiple PIDs, $status will be set with the status of each process. Example:

```
; true&false&true& wait $apids; whatis status
status=(0 1 0)
```

This is an extra feature not present in Plan 9 rc.

Note that calling wait without argument keeps its standard behavior and only returns the status of the last terminated process.