### PR TITLE
Add "continue" to the list of differences from plan9 in man page

### DIFF
--- a/rc.1
+++ b/rc.1
@@ -2277,7 +2277,8 @@ flag,
 here strings (they facilitate exporting of functions
 with here documents into the environment),
 the
-.B return
+.B return,
+.B continue,
 and
 .B break
 keywords,


### PR DESCRIPTION
Currently listed in the man page are builtins `break` and `return`. Add `continue`.