### PR TITLE
Update dead link in man page

### DIFF
--- a/rc.1
+++ b/rc.1
@@ -2310,7 +2310,7 @@ Unix Research System,
 Tenth Edition,
 Volume 2. (Saunders College Publishing)
 .PP
-.Cr http://static.tobold.org/rc/rc-duff.html ,
+.Cr https://doc.cat-v.org/plan_9/2nd_edition/papers/rc/ ,
 an updated version of the above paper.
 .PP
 .IR history (1)


### PR DESCRIPTION
Replace dead link to Duff's paper in man page with link to archived page.