### PR TITLE
Support bestline for line editing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# line editing library: null, edit, editline, readline, vrl
+# line editing library: null, edit, editline, readline, vrl, bestline
 EDIT = null
 
 srcdir = .

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,20 @@ check: trip
 trip: rc tripping
 	./rc -p <"$(srcdir)/trip.rc"
 
+acutest.h:; wget --compression=gzip https://raw.githubusercontent.com/mity/acutest/master/include/acutest.h
+
+test-bestline.o: test-bestline.c edit-bestline.c acutest.h
+
+test-bestline: test-bestline.o $(filter-out main.o edit-null.o ,$(OBJS))
+	$(CC) $(_LDFLAGS) $(_CFLAGS) -o $@ $^ -lbestline $(LDLIBS)
+
+run-test-bestline: test-bestline
+	mkdir -p /tmp/rc/fakebin
+	touch /tmp/rc/hello /tmp/rc/world '/tmp/rc/world wide'
+	touch /tmp/rc/fakebin/vim /tmp/rc/fakebin/emacs /tmp/rc/fakebin/ed
+	chmod +x /tmp/rc/fakebin/vim /tmp/rc/fakebin/emacs /tmp/rc/fakebin/ed
+	./test-bestline
+
 clean:
 	rm -f *.o $(BINS) rc
 

--- a/README
+++ b/README
@@ -37,8 +37,8 @@ second command to:
 	# make PREFIX="/your/dir" install
 
 The EDIT make macro controls which line-editing library to use: null,
-edit, editline, readline, vrl. For example, to make rc use the readline
-library, you have to build it with the following command:
+edit, editline, readline, vrl, bestline. For example, to make rc use the
+readline library, you have to build it with the following command:
 
 	$ make EDIT=readline
 

--- a/edit-bestline.c
+++ b/edit-bestline.c
@@ -1,0 +1,328 @@
+#include "rc.h"
+
+#include <ctype.h>
+#include <errno.h>
+#include <stdio.h>
+#include <dirent.h>
+#include <sys/stat.h>
+#include <bestline.h>
+
+#include "edit.h"
+
+bool editing = 1;
+
+struct cookie {
+	char *buffer;
+};
+
+/* Join two strings with a "/" between them, into a malloc string */
+static char *dir_join(const char *a, const char *b) {
+	size_t l;
+	if (!a) a = "";
+	if (!b) b = "";
+	l = strlen(a);
+	return mprint("%s%s%s", a, l && a[l-1] != '/' ? "/" : "", b);
+}
+
+static char *quote(char *str) {
+	size_t quotecount = 0;
+	for (char *p = str; *p; p++)
+		if (*p == '\'') quotecount++;
+	size_t newlen = strlen(str) + quotecount + 2;
+	char *quoted = ealloc(newlen + 1);
+	quoted[0] = '\'';
+	char *q = quoted + 1;
+	for (char *p = str; *p; p++, q++) {
+		*q = *p;
+		if (*p == '\'')
+			*(++q) = '\'';
+	}
+	*q = '\'';
+	*(q+1) = '\0';
+	return quoted;
+}
+
+static void strip_quotes(char *str) {
+	bool quoted = 0;
+	for (char *p = str; *p; p++) {
+		if (*p == '\'') {
+			if (p[1] == '\'') {
+				if (quoted) {
+					// unescape single quote
+					memmove(p, p+1, strlen(p+1) + 1);
+					// don't decrement p -> step over the remaining quote
+				} else {
+					// ignore empty string
+					memmove(p, p+2, strlen(p+2) + 1);
+					p--;
+				}
+			} else {
+				// strip single quote (opening or closing)
+				memmove(p, p+1, strlen(p+1) + 1);
+				p--;
+				quoted = !quoted;
+			}
+		}
+	}
+}
+
+/* Decide if this directory entry is a completion candidate, either executable
+ * or a directory. "dname" is the absolute path of the directory, "name" is the
+ * current entry. "subdirs" is the name being completed up to and including the
+ * last slash (or NULL if there is no slash), "prefix" is the remainder of the
+ * name being completed, "len" is the length of "prefix".
+ */
+static char *entry(char *dname, char *name, char *subdirs,
+			char *prefix, size_t len) {
+	char *full;
+	struct stat st;
+
+	if (strncmp(name, prefix, len) != 0)
+		return NULL;
+	if (streq(name, ".") || streq(name, ".."))
+		return NULL;
+	full = dir_join(dname, name);
+	int exe = rc_access(full, FALSE, &st);
+	efree(full);
+	if (exe || S_ISDIR(st.st_mode))
+		return dir_join(subdirs, name);
+	return NULL;
+}
+
+/* Split a string "text" after the last "/" into "pre" and "post". If there is
+ * no "/", "pre" will be NULL. */
+static void split_last_slash(const char *text, char **pre, char **post) {
+	char *last_slash = strrchr(text, '/');
+	if (last_slash) {
+		size_t l = last_slash + 1 - text;
+		*pre = ealloc(l + 1);
+		memcpy(*pre, text, l);
+		(*pre)[l] = '\0';
+		*post = last_slash + 1;
+	} else {
+		*pre = NULL;
+		*post = (char *)text;
+	}
+}
+
+static char *compl_extcmd(const char *text, int state) {
+	static char *dname, *prefix, *subdirs;
+	static DIR *d;
+	static List nil, *path;
+	static size_t len;
+
+	if (!state) {
+		split_last_slash(text, &subdirs, &prefix);
+		d = NULL;
+		if (subdirs && isabsolute(subdirs))
+			path = &nil;
+		else
+			path = varlookup("path");
+		len = strlen(prefix);
+	}
+	while (d || path) {
+		if (!d) {
+			dname = dir_join(path->w, subdirs);
+			d = opendir(dname);
+			path = path->n;
+			if (!d) efree(dname);
+		} else {
+			struct dirent *e;
+			while ((e = readdir(d))) {
+				char *x;
+				x = entry(dname, e->d_name, subdirs,
+						prefix, len);
+				if (x) return x;
+			}
+			closedir(d);
+			efree(dname);
+			d = NULL;
+		}
+	}
+	efree(subdirs);
+	return NULL;
+}
+
+static char *compl_filename(const char *text, int state) {
+	static char *textnoquotes, *dname, *prefix, *subdirs;
+	static DIR *d;
+	static size_t len;
+	if (!state) {
+		textnoquotes = strdup(text);
+		strip_quotes(textnoquotes);
+		text = textnoquotes;
+		split_last_slash(text, &subdirs, &prefix);
+		len = strlen(prefix);
+		d = opendir(subdirs ? subdirs : ".");
+		if (!d) {
+			efree(subdirs);
+			efree(textnoquotes);
+			return NULL;
+		}
+	}
+	struct dirent *e;
+	while ((e = readdir(d))) {
+		if (streq(e->d_name, ".") || streq(e->d_name, ".."))
+			continue;
+		dname = NULL;
+		if (strncmp(e->d_name, prefix, len) == 0) {
+			dname = subdirs ? dir_join(subdirs, e->d_name) : strdup(e->d_name);
+			if (strstr(dname, " ")) {
+				char *quoted = quote(dname);
+				efree(dname);
+				dname = quoted;
+			}
+			return dname;
+		}
+	}
+	closedir(d);
+	d = NULL;
+	efree(subdirs);
+	efree(dname);
+	efree(textnoquotes);
+	return NULL;
+}
+
+static char compl_prefix(const char *buf, int index) {
+	while (index-- > 0) {
+		char c = buf[index];
+		if (c != ' ' && c != '\t')
+			return c;
+	}
+	return ';';
+}
+
+static int findbeginningoftoken(const char *buf, int cursorpos) {
+	bool quoted = 0;
+	int beginning = 0;
+	for (const char *p = buf; *p && p < buf + cursorpos; p++) {
+		if (*p == '\'') {
+			quoted = !quoted;
+		} else if (!quoted && (*p == ' ' || *p == ';' || *p == '$')) {
+			beginning = p - buf + 1;
+		}
+	}
+	return beginning;
+}
+
+static int quotedstrcmp(const void *s1, const void *s2) {
+	char *c1 = *(char**)s1;
+	char *c2 = *(char**)s2;
+	for (; *c1 && *c2; c1++, c2++) {
+		while (*c1 == '\'') c1++;
+		while (*c2 == '\'') c2++;
+		if (*c1 != *c2) break;
+	}
+	return (int)(*c1 - *c2);
+}
+
+static void add_completions(const char *buf, int start, int end,
+		char* (*compl_func)(const char*, int), bestlineCompletions *lc) {
+	char *token = strndup(buf + start, end - start);
+	char *match = compl_func(token, 0);
+	while (match) {
+		size_t len = strlen(buf) - (end - start) + strlen(match) + 1;
+		char *completion = (char*)ealloc(len);
+		snprintf(completion, len, "%.*s%s%s", start, buf, match, &buf[end]);
+		bool duplicate = 0;
+		if (strcmp(buf, completion) == 0) {
+			duplicate = 1;
+		} else for (int i = 0; i < lc->len; ++i) {
+			if (strcmp(lc->cvec[i], completion) == 0
+					|| strcmp(buf, completion) == 0) {
+				duplicate = 1;
+				break;
+			}
+		}
+		if (!duplicate) {
+			bestlineAddCompletion(lc, completion);
+		}
+		efree(completion);
+		match = compl_func(token, 1);
+	}
+	efree(token);
+	if (lc->len > 1)
+		qsort(lc->cvec, lc->len, sizeof(char*), quotedstrcmp);
+}
+
+static void completion(const char *buf, int pos, bestlineCompletions *lc) {
+	int startindex = findbeginningoftoken(buf, pos);
+	char prefix = compl_prefix(buf, startindex);
+	switch (prefix) {
+		case '`': case '@': case '|': case '&':
+		case '(': case ')': case '{': case ';':
+			add_completions(buf, startindex, pos, &compl_builtin, lc);
+			add_completions(buf, startindex, pos, &compl_fn, lc);
+			add_completions(buf, startindex, pos, &compl_extcmd, lc);
+			return;
+		case '$':
+			add_completions(buf, startindex, pos, &compl_var, lc);
+			return;
+	}
+	// replace ~/ with $HOME/
+	char *expandedbuf = NULL;
+	if (buf[startindex] == '~' && buf[startindex + 1] == '/') {
+		const char* home = getenv("HOME");
+		if (home) {
+			size_t homelen = strlen(home);
+			expandedbuf = ealloc(strlen(buf) + homelen);
+			sprintf(expandedbuf, "%.*s%s%s", startindex, buf, home, buf + startindex + 1);
+			buf = expandedbuf;
+			pos += homelen - 1;
+		}
+	}
+	add_completions(buf, startindex, pos, &compl_filename, lc);
+	efree(expandedbuf);
+}
+
+void *edit_begin(int fd) {
+	List *hist;
+	struct cookie *c;
+
+	bestlineSetCompletionCallback(completion);
+
+	hist = varlookup("history");
+	if (hist != NULL)
+		if (bestlineHistoryLoad(hist->w) != 0 &&
+				errno != ENOENT) /* ignore if missing */
+			uerror(hist->w);
+
+	c = ealloc(sizeof *c);
+	c->buffer = NULL;
+	return c;
+}
+
+static char *prompt;
+
+char *edit_alloc(void *cookie, size_t *count) {
+	struct cookie *c = cookie;
+	c->buffer = bestline(prompt);
+	if (c->buffer) {
+		*count = strlen(c->buffer);
+		if (*count) {
+			bestlineHistoryAdd(c->buffer);
+			c->buffer[*count] = '\n';
+			++*count;
+		}
+	}
+	return c->buffer;
+}
+
+void edit_prompt(void *cookie, char *pr) {
+	prompt = pr;
+}
+
+void edit_free(void *cookie) {
+	struct cookie *c = cookie;
+	efree(c->buffer);
+	c->buffer = NULL; /* allow "overfrees" */
+}
+
+void edit_end(void *cookie) {
+	struct cookie *c = cookie;
+	efree(c);
+}
+
+void edit_reset(void *cookie) {
+	// do nothing
+}

--- a/test-bestline.c
+++ b/test-bestline.c
@@ -1,0 +1,284 @@
+#include "edit-bestline.c"
+#include "version.h"
+#include "acutest.h"
+
+#define TEST_CHECK_INT(var, expected) \
+	(TEST_CHECK_(var == expected, "%s = %i (exp.: %i)", \
+		#var, (int)var, (int)expected))
+
+#define TEST_ASSERT_INT(var, expected) \
+	TEST_ASSERT_(var == expected, "%s = %i (exp.: %i)", \
+		#var, (int)var, (int)expected)
+
+#define TEST_CHECK_STR(var, expected) \
+	(TEST_CHECK_(streq(var, expected), "%s = \"%s\" (exp.: \"%s\")", \
+		#var, var, expected))
+
+
+bool dashdee, dashee, dasheye, dashell, dashen;
+bool dashpee, dashoh, dashess, dashvee, dashex;
+bool interactive;
+char *dashsee[2];
+pid_t rc_pid;
+char* envp[] = {
+	"PATH=/tmp/rc/fakebin",
+	"fn_edit={emacs $*}",
+	"fn_editor={ed $*}",
+	"fn_v={vim $*}",
+	NULL};
+
+bestlineCompletions lc = {0};
+
+static void assigndefault(char *name,...) {
+	va_list ap;
+	List *l;
+	char *v;
+	va_start(ap, name);
+	for (l = NULL; (v = va_arg(ap, char *)) != NULL;)
+		l = append(l, word(v, NULL));
+	varassign(name, l, FALSE);
+	set_exportable(name, FALSE);
+	if (streq(name, "path"))
+		alias(name, l, FALSE);
+	va_end(ap);
+}
+
+static void init(void) {
+	static bool executed = 0;
+	if (executed) return;
+	rc_pid = getpid();
+	inithash();
+	assigndefault("ifs", " ", "\t", "\n", (void *)0);
+	assigndefault("nl", "\n", (void *)0);
+	assigndefault("pid", nprint("%d", rc_pid), (void *)0);
+	assigndefault("prompt", "; ", "", (void *)0);
+	assigndefault("tab", "\t", (void *)0);
+	assigndefault("version", VERSION, (void *)0);
+	executed = 1;
+}
+
+static void reset_completions(void) {
+	bestlineFreeCompletions(&lc);
+	lc.len = 0;
+	lc.cvec = NULL;
+}
+
+void test_quote(void) {
+	TEST_CHECK_STR(quote("my file"), "'my file'");
+	TEST_CHECK_STR(quote("it's a file"), "'it''s a file'");
+}
+
+void test_strip_quotes(void) {
+	char str[] = "'my file'";
+	strip_quotes(str);
+	TEST_CHECK_STR(str, "my file");
+	char str2[] = "my' 'file";
+	strip_quotes(str2);
+	TEST_CHECK_STR(str2, "my file");
+	char str3[] = "my fi'le";
+	strip_quotes(str3);
+	TEST_CHECK_STR(str3, "my file");
+	char str4[] = "my''file";
+	strip_quotes(str4);
+	TEST_CHECK_STR(str4, "myfile");
+	char str5[] = "'my''file";
+	strip_quotes(str5);
+	TEST_CHECK_STR(str5, "my'file");
+}
+
+void test_findbeginningoftoken(void) {
+	TEST_CHECK_INT(findbeginningoftoken("echo hello", 10), 5);
+	TEST_CHECK_INT(findbeginningoftoken("echo 'hello", 11), 5);
+	TEST_CHECK_INT(findbeginningoftoken("echo 'hello wo", 14), 5);
+	TEST_CHECK_INT(findbeginningoftoken("echo 'hello world'", 18), 5);
+	TEST_CHECK_INT(findbeginningoftoken("echo hello' 'world", 18), 5);
+	TEST_CHECK_INT(findbeginningoftoken("echo hello^' '^world", 20), 5);
+	TEST_CHECK_INT(findbeginningoftoken("echo hello' world'", 18), 5);
+	TEST_CHECK_INT(findbeginningoftoken("echo 'it''s me", 14), 5);
+	TEST_CHECK_INT(findbeginningoftoken("ls '/home/x/My Docum", 20), 3);
+}
+
+void test_completion_builtins(void) {
+	init();
+
+	// one match
+	reset_completions();
+	completion("buil", 4, &lc);
+	TEST_CHECK_INT(lc.len, 1);
+	TEST_CHECK_STR(lc.cvec[0], "builtin");
+
+	// two matches
+	reset_completions();
+	completion("ex", 2, &lc);
+	TEST_CHECK(lc.len == 2);
+	TEST_CHECK_STR(lc.cvec[0], "exec");
+	TEST_CHECK_STR(lc.cvec[1], "exit");
+
+	// no matches
+	reset_completions();
+	completion("d", 1, &lc);
+	TEST_CHECK_INT(lc.len, 0);
+
+	// one match, cursor in word (between 'i' and 'l')
+	reset_completions();
+	completion("buil", 3, &lc);
+	TEST_CHECK_INT(lc.len, 1);
+	TEST_CHECK_STR(lc.cvec[0], "builtinl");
+
+	// one match, cursor not at end
+	reset_completions();
+	completion("what $PATH", 4, &lc);
+	TEST_CHECK_INT(lc.len, 1);
+	TEST_CHECK_STR(lc.cvec[0], "whatis $PATH");
+}
+
+void test_completion_functions(void) {
+	init();
+	initenv(envp);
+
+	// no matches
+	reset_completions();
+	add_completions("xy", 0, 2, &compl_fn, &lc);
+	TEST_CHECK_INT(lc.len, 0);
+
+	// two matches
+	reset_completions();
+	add_completions("ed", 0, 2, &compl_fn, &lc);
+	TEST_ASSERT_INT(lc.len, 2);
+	TEST_CHECK_STR(lc.cvec[0], "edit");
+	TEST_CHECK_STR(lc.cvec[1], "editor");
+
+	// two matches, cursor not at end
+	reset_completions();
+	add_completions("ed myfile", 0, 2, &compl_fn, &lc);
+	TEST_ASSERT_INT(lc.len, 2);
+	TEST_CHECK_STR(lc.cvec[0], "edit myfile");
+	TEST_CHECK_STR(lc.cvec[1], "editor myfile");
+}
+
+void test_completion_commands(void) {
+	init();
+	initenv(envp);
+
+	// one match
+	reset_completions();
+	completion("vi", 2, &lc);
+	TEST_ASSERT_INT(lc.len, 1);
+	TEST_CHECK_STR(lc.cvec[0], "vim");
+
+	// two matches
+	reset_completions();
+	add_completions("e", 0, 1, &compl_extcmd, &lc);
+	TEST_ASSERT_INT(lc.len, 2);
+	TEST_CHECK_STR(lc.cvec[0], "ed");
+	TEST_CHECK_STR(lc.cvec[1], "emacs");
+
+	// no matches
+	reset_completions();
+	completion("xy", 2, &lc);
+	TEST_CHECK_INT(lc.len, 0);
+}
+
+void test_completion_variables(void) {
+	init();
+	initenv(envp);
+
+	// one match
+	reset_completions();
+	completion("echo $PA", 8, &lc);
+	TEST_ASSERT_INT(lc.len, 1);
+	TEST_CHECK_STR(lc.cvec[0], "echo $PATH");
+
+	// no matches
+	reset_completions();
+	completion("echo $XY", 8, &lc);
+	TEST_CHECK(lc.len == 0);
+}
+
+void test_completion_filenames(void) {
+	init();
+	initenv(envp);
+
+	// no matches
+	reset_completions();
+	add_completions("ls /tmp/rc/x", 3, 12, &compl_filename, &lc);
+	TEST_CHECK(lc.len == 0);
+
+	// one match
+	reset_completions();
+	add_completions("ls /tmp/rc/he", 3, 13, &compl_filename, &lc);
+	TEST_ASSERT_INT(lc.len, 1);
+	TEST_CHECK_STR(lc.cvec[0], "ls /tmp/rc/hello");
+
+	// three matches, one of them with whitespace
+	reset_completions();
+	add_completions("ls /tmp/rc/", 3, 11, &compl_filename, &lc);
+	TEST_ASSERT_INT(lc.len, 5);
+	TEST_CHECK_STR(lc.cvec[0], "ls /tmp/rc/fakebin");
+	TEST_CHECK_STR(lc.cvec[1], "ls /tmp/rc/hello");
+	TEST_CHECK_STR(lc.cvec[2], "ls '/tmp/rc/it''s rc'");
+	TEST_CHECK_STR(lc.cvec[3], "ls /tmp/rc/world");
+	TEST_CHECK_STR(lc.cvec[4], "ls '/tmp/rc/world wide'");
+
+	// empty string
+	reset_completions();
+	completion("ls ", 3, &lc);
+	TEST_CHECK(lc.len > 0);
+
+	// with ~, one match
+	reset_completions();
+	// call completion instead of add_completions to get ~ expanded
+	completion("ls ~/.", 6, &lc);
+	TEST_ASSERT(lc.len > 0);
+
+	// before space, unquoted, two matches
+	reset_completions();
+	completion("ls /tmp/rc/wor", 14, &lc);
+	TEST_ASSERT_INT(lc.len, 2);
+	TEST_CHECK_STR(lc.cvec[0], "ls /tmp/rc/world");
+	TEST_CHECK_STR(lc.cvec[1], "ls '/tmp/rc/world wide'");
+
+	// after space, quoted, one match
+	reset_completions();
+	completion("ls '/tmp/rc/world wi", 20, &lc);
+	TEST_ASSERT_INT(lc.len, 1);
+	TEST_CHECK_STR(lc.cvec[0], "ls '/tmp/rc/world wide'");
+
+	// quoted space, one match
+	reset_completions();
+	completion("ls /tmp/rc/world' ", 18, &lc);
+	TEST_ASSERT_INT(lc.len, 1);
+	TEST_CHECK_STR(lc.cvec[0], "ls '/tmp/rc/world wide'");
+
+	// quoted space, one match
+	reset_completions();
+	completion("ls /tmp/rc/'world ", 18, &lc);
+	TEST_ASSERT_INT(lc.len, 1);
+	TEST_CHECK_STR(lc.cvec[0], "ls '/tmp/rc/world wide'");
+
+	// empty quotes, one match
+	reset_completions();
+	completion("ls /tmp/rc/it''", 15, &lc);
+	// '' does not expand to a single quote. It's an empty string and can be ignored.
+	TEST_ASSERT_INT(lc.len, 1);
+	TEST_CHECK_STR(lc.cvec[0], "ls '/tmp/rc/it''s rc'");
+
+	// escaped single quote, one match
+	reset_completions();
+	completion("ls '/tmp/rc/it''", 16, &lc);
+	// Now, '' is an escaped single quote and must not be ignored.
+	TEST_ASSERT_INT(lc.len, 1);
+	TEST_CHECK_STR(lc.cvec[0], "ls '/tmp/rc/it''s rc'");
+}
+
+TEST_LIST = {
+	{ "quote", test_quote },
+	{ "stripquotes", test_strip_quotes },
+	{ "beginning", test_findbeginningoftoken },
+	{ "builtins", test_completion_builtins },
+	{ "functions", test_completion_functions },
+	{ "commands", test_completion_commands },
+	{ "variables", test_completion_variables },
+	{ "filenames", test_completion_filenames },
+	{ NULL, NULL }     /* zeroed record marking the end of the list */
+};


### PR DESCRIPTION
# Support bestline for line editing

[bestline](https://github.com/jart/bestline) is a small line editing library (roughly 3000 lines of code) based on [linenoise](https://github.com/antirez/linenoise).

> Bestline is a fork of linenoise (a popular readline alternative) that fixes
> its bugs and adds the missing features while reducing binary footprint
> (surprisingly) by removing bloated dependencies, which means you can finally
> have a permissively-licensed command prompt w/ a 38kb footprint that's nearly
> as good as gnu readline.

## Installation

First, install a patched version of bestline as dynamic library:

```sh
git clone -b lib https://github.com/MaxGyver83/bestline.git
cd bestline
make libbestline.so
sudo cp libbestline.so /usr/local/lib/
sudo cp bestline.h /usr/local/include/
```

This patch adds a _position_ argument to bestline's `completion` function. The cursor position is necessary to decide which part of the current command is to be completed. The cursor position is updated for completion that don't happen at the end of a line. It also adds a `make` target for building a dynamic library. (In [integrate Antirez's linenoise single file zero conf line editing by rlonstein · Pull Request #5 · rakitzis/rc](https://github.com/rakitzis/rc/pull/5), it was suggested to provide linenoise as a standalone library.) I'll open a pull request with these changes to bestline.

Then, build rc with bestline support:

```sh
cd /path/to/rc
make EDIT=bestline
```

## Features

Bestline states to be "nearly as good as gnu readline".

Some differences compared to readline:

- No insertion of the last argument of the previous command (`Alt+.` in readline).
- Up arrow doesn't consider typed characters (`history-search-backward`). Use `Ctrl+r` instead.
- After deleting two words with `Ctrl+w w`, `Ctrl+y` inserts only the first word (with readline it inserts both words).
- Tab completion iterates over possible completions but doesn't print a list.

Bonus in this integration:

- Filename completion expands `~/dir` to `$HOME/dir`.