### PR TITLE
bestline: Avoid null character warning for empty commands

### DIFF
--- a/edit-bestline.c
+++ b/edit-bestline.c
@@ -299,11 +299,10 @@ char *edit_alloc(void *cookie, size_t *count) {
 	c->buffer = bestline(prompt);
 	if (c->buffer) {
 		*count = strlen(c->buffer);
-		if (*count) {
+		if (*count)
 			bestlineHistoryAdd(c->buffer);
-			c->buffer[*count] = '\n';
-			++*count;
-		}
+		c->buffer[*count] = '\n';
+		++*count; /* include the \n */
 	}
 	return c->buffer;
 }


### PR DESCRIPTION
When using rc linked with bestline, you get this warning after executing an "empty" command:

```
warning: null character ignored
```

This pull request fixes this by overwriting the final `\0` with `\n` also for empty commands.