### PR TITLE
Catch end-of-string in the source string when performing a range match

### DIFF
--- a/match.c
+++ b/match.c
@@ -26,14 +26,15 @@ extern bool match(char *p, char *m, char *s) {
 					continue;
 				}
 				break;
-			case '[': {
-				int r = 1 + rangematch(p+1, *s);
-				if (r > 0) {
-					p += r, m += r, s++;
-					continue;
+			case '[':
+				if (*s) {
+					int r = 1 + rangematch(p+1, *s);
+					if (r > 0) {
+						p += r, m += r, s++;
+						continue;
+					}
 				}
 				break;
-			}
 			case '*':
 				next.p = p++;
 				next.m = m++;
@@ -42,7 +43,6 @@ extern bool match(char *p, char *m, char *s) {
 			default:
 				panic("bad metacharacter in match");
 				/* NOTREACHED */
-				return FALSE; /* hush up gcc -Wall */
 			}
 		}
 		if (next.s != NULL) {

--- a/trip.rc
+++ b/trip.rc
@@ -358,6 +358,10 @@ if (~ x [y])
 	fail rangematch out of range
 if (~ x x?)
 	fail too many characters in pattern
+if (~ . .[~.])
+	fail matched nul terminator
+if (~ aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab a*a*a*a*a*a*a*a)
+	fail this should finish in linear time
 
 sh -c 'test -f /////$tmpdir//////a?c.'^$pid || fail glob with many slashes
 if (!~ /////$tmpdir//////a*.$pid /////$tmpdir//////a?c.$pid)


### PR DESCRIPTION
This commit guards the case for range matches (e.g., "[a-z]") with an end-of-string check for the source string.

This prevents an inadvertent interpretation of the nul terminator as a matching character, as well as preventing bugs as in issue #115.